### PR TITLE
net: add new signetpsbt message

### DIFF
--- a/src/protocol.h
+++ b/src/protocol.h
@@ -59,6 +59,12 @@ public:
  */
 namespace NetMsgType {
 /**
+ * The signetpsbt message transports a PSBT with taproot fields to collect signatures
+ * required to satisfy the signet challenge multisig. A serialized block template whose 
+ * block_data as specified in BIP 325 matches the commitment in the PSBT.
+ */
+inline constexpr const char* SIGNETPSBT{"signetpsbt"};
+/**
  * The version message provides information about the transmitting node to the
  * receiving node at the beginning of a connection.
  */
@@ -268,6 +274,7 @@ inline constexpr const char* SENDTXRCNCL{"sendtxrcncl"};
 
 /** All known message types (see above). Keep this in the same order as the list of messages above. */
 inline const std::array ALL_NET_MESSAGE_TYPES{std::to_array<std::string>({
+    NetMsgType::SIGNETPSBT,
     NetMsgType::VERSION,
     NetMsgType::VERACK,
     NetMsgType::ADDR,


### PR DESCRIPTION
This PR adds the needed network message to relay the blocks with the PSBT.
The message is defined in the [specification](https://github.com/quorumeum-floripa-2026/quorumeum/blob/main/README.md#specification).

Behavior for this message still needs to be defined.

hint for other devs: Behavior must be defined in `net_processing.cpp`