### PR TITLE
net: deserialize and log signetpsbt P2P message

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -45,6 +45,7 @@
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <protocol.h>
+#include <psbt.h>
 #include <random.h>
 #include <scheduler.h>
 #include <script/script.h>
@@ -3828,6 +3829,20 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
 
     if (!pfrom.fSuccessfullyConnected) {
         LogDebug(BCLog::NET, "Unsupported message \"%s\" prior to verack from peer=%d\n", SanitizeString(msg_type), pfrom.GetId());
+        return;
+    }
+
+    if (msg_type == NetMsgType::SIGNETPSBT) {
+        PartiallySignedTransaction psbt;
+        CBlock block;
+        try {
+            vRecv >> psbt;
+            vRecv >> TX_WITH_WITNESS(block);
+        } catch (const std::exception& e) {
+            LogDebug(BCLog::NET, "Invalid signetpsbt from peer=%d: %s\n", pfrom.GetId(), e.what());
+            return;
+        }
+        LogPrintf("Received signetpsbt from peer=%d prevhash=%s\n", pfrom.GetId(), block.hashPrevBlock.ToString());
         return;
     }
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3835,13 +3835,8 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
     if (msg_type == NetMsgType::SIGNETPSBT) {
         PartiallySignedTransaction psbt;
         CBlock block;
-        try {
-            vRecv >> psbt;
-            vRecv >> TX_WITH_WITNESS(block);
-        } catch (const std::exception& e) {
-            LogDebug(BCLog::NET, "Invalid signetpsbt from peer=%d: %s\n", pfrom.GetId(), e.what());
-            return;
-        }
+        vRecv >> psbt;
+        vRecv >> TX_WITH_WITNESS(block);
         LogPrintf("Received signetpsbt from peer=%d prevhash=%s\n", pfrom.GetId(), block.hashPrevBlock.ToString());
         return;
     }


### PR DESCRIPTION
 Add a handler for the `signetpsbt` message in `ProcessMessage()`.

 The message carries a PSBT (collecting multisig signatures) followed  by a serialized block template. On receipt the handler deserializes  both fields, logs the prevhash, and returns. Malformed messages are  caught and logged without disconnecting the peer.

This is the minimal scaffolding needed for other contributors to build on: validation, signing, relay, and block finalization.

issue related : #16 