### PR TITLE
Feature: Add -descriptor startup argument

### DIFF
--- a/src/common/args.cpp
+++ b/src/common/args.cpp
@@ -8,6 +8,7 @@
 #include <chainparamsbase.h>
 #include <common/settings.h>
 #include <logging.h>
+#include <script/descriptor.h>
 #include <sync.h>
 #include <tinyformat.h>
 #include <univalue.h>
@@ -40,6 +41,7 @@ const char * const BITCOIN_CONF_FILENAME = "bitcoin.conf";
 const char * const BITCOIN_SETTINGS_FILENAME = "settings.json";
 
 ArgsManager gArgs;
+std::unique_ptr<Descriptor> g_descriptor;
 
 /**
  * Interpret a string argument as a boolean.

--- a/src/common/args.h
+++ b/src/common/args.h
@@ -450,6 +450,9 @@ private:
 
 extern ArgsManager gArgs;
 
+struct Descriptor;  // Forward declaration
+extern std::unique_ptr<Descriptor> g_descriptor;
+
 /**
  * @return true if help has been requested via a command-line arg
  */

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -56,7 +56,8 @@ add_executable(test_bitcoin
 #  mempool_tests.cpp
 #  merkle_tests.cpp
 #  merkleblock_tests.cpp
-  miner_tests.cpp
+miner_tests.cpp
+g_descriptor_tests.cpp
 #  miniminer_tests.cpp
 #  miniscript_tests.cpp
 #  minisketch_tests.cpp

--- a/src/test/g_descriptor_tests.cpp
+++ b/src/test/g_descriptor_tests.cpp
@@ -1,0 +1,205 @@
+// Copyright (c) 2024-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <common/args.h>
+#include <script/descriptor.h>
+#include <script/signingprovider.h>
+#include <test/util/logging.h>
+#include <test/util/setup_common.h>
+#include <util/strencodings.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <memory>
+#include <string>
+
+BOOST_FIXTURE_TEST_SUITE(g_descriptor_tests, BasicTestingSetup)
+
+// Helper function to parse a descriptor string
+std::unique_ptr<Descriptor> ParseTestDescriptor(const std::string& desc_str)
+{
+    FlatSigningProvider keys;
+    std::string error;
+    auto descs = Parse(desc_str, keys, error, /*require_checksum=*/false);
+    if (descs.empty()) {
+        BOOST_FAIL("Failed to parse descriptor: " + error);
+    }
+    return std::move(descs.front());
+}
+
+BOOST_AUTO_TEST_CASE(g_descriptor_singleton_exists)
+{
+    // Verify that g_descriptor is declared and can be accessed
+    BOOST_CHECK(true); // Compilation itself is the test
+}
+
+BOOST_AUTO_TEST_CASE(descriptor_parsing_valid_pkh)
+{
+    // Test parsing a simple pay-to-pubkey-hash descriptor
+    std::string desc_str = "pkh([d34db33f/44'/0'/0']xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB/0/*)";
+    
+    auto desc = ParseTestDescriptor(desc_str);
+    BOOST_CHECK(desc != nullptr);
+    BOOST_CHECK(desc->IsSingleType());
+}
+
+BOOST_AUTO_TEST_CASE(descriptor_parsing_valid_tr)
+{
+    // Test parsing a Taproot descriptor
+    std::string desc_str = "tr(xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB/0/*)";
+    
+    auto desc = ParseTestDescriptor(desc_str);
+    BOOST_CHECK(desc != nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(descriptor_parsing_ranged)
+{
+    // Test parsing a ranged descriptor
+    std::string desc_str = "pkh(xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB/0/*)";
+    
+    auto desc = ParseTestDescriptor(desc_str);
+    BOOST_CHECK(desc != nullptr);
+    BOOST_CHECK(desc->IsRange());
+}
+
+BOOST_AUTO_TEST_CASE(descriptor_parsing_multiple_keys)
+{
+    // Test parsing a multi-signature descriptor
+    std::string desc_str = "sh(multi(2,xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB,xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB))";
+    
+    auto desc = ParseTestDescriptor(desc_str);
+    BOOST_CHECK(desc != nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(descriptor_parsing_invalid)
+{
+    // Test that invalid descriptors fail gracefully
+    FlatSigningProvider keys;
+    std::string error;
+    
+    // Invalid descriptor syntax
+    auto descs = Parse("invalid_descriptor", keys, error, /*require_checksum=*/false);
+    BOOST_CHECK(descs.empty());
+    BOOST_CHECK(!error.empty());
+}
+
+BOOST_AUTO_TEST_CASE(descriptor_parsing_malformed_key)
+{
+    // Test descriptor with malformed key
+    FlatSigningProvider keys;
+    std::string error;
+    
+    auto descs = Parse("pkh(invalid_key)", keys, error, /*require_checksum=*/false);
+    BOOST_CHECK(descs.empty());
+    BOOST_CHECK(!error.empty());
+}
+
+BOOST_AUTO_TEST_CASE(descriptor_output_type_legacy)
+{
+    // Test that pkh descriptor has correct output type (LEGACY)
+    std::string desc_str = "pkh([d34db33f/44'/0'/0']xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB/0/*)";
+    
+    auto desc = ParseTestDescriptor(desc_str);
+    BOOST_CHECK_EQUAL(desc->GetOutputType(), OutputType::LEGACY);
+}
+
+BOOST_AUTO_TEST_CASE(descriptor_output_type_bech32)
+{
+    // Test that wpkh descriptor has correct output type (BECH32)
+    std::string desc_str = "wpkh(xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB/0/*)";
+    
+    auto desc = ParseTestDescriptor(desc_str);
+    BOOST_CHECK_EQUAL(desc->GetOutputType(), OutputType::BECH32);
+}
+
+BOOST_AUTO_TEST_CASE(descriptor_output_type_bech32m)
+{
+    // Test that tr descriptor has correct output type (BECH32M)
+    std::string desc_str = "tr(xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB/0/*)";
+    
+    auto desc = ParseTestDescriptor(desc_str);
+    BOOST_CHECK_EQUAL(desc->GetOutputType(), OutputType::BECH32M);
+}
+
+BOOST_AUTO_TEST_CASE(descriptor_solvable)
+{
+    // Test that solvable descriptors are marked as such
+    std::string desc_str = "pkh(xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB/0/*)";
+    
+    auto desc = ParseTestDescriptor(desc_str);
+    BOOST_CHECK(desc->IsSolvable());
+}
+
+BOOST_AUTO_TEST_CASE(descriptor_multiple_valid_parsings)
+{
+    // Test various valid descriptor formats
+    std::vector<std::string> valid_descriptors = {
+        "pk(xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB)",
+        "pkh(xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB)",
+        "wpkh(xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB)",
+    };
+    
+    for (const auto& desc_str : valid_descriptors) {
+        auto desc = ParseTestDescriptor(desc_str);
+        BOOST_CHECK(desc != nullptr);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(descriptor_checksum_generation)
+{
+    // Test descriptor checksum generation
+    std::string desc_str = "pkh(xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB)";
+    
+    // Generate checksum for descriptor
+    std::string checksum = GetDescriptorChecksum(desc_str);
+    BOOST_CHECK(!checksum.empty());
+    
+    // Verify descriptor with checksum parses
+    std::string desc_with_checksum = desc_str + "#" + checksum;
+    FlatSigningProvider keys;
+    std::string error;
+    auto descs = Parse(desc_with_checksum, keys, error, /*require_checksum=*/false);
+    BOOST_CHECK(!descs.empty());
+}
+
+BOOST_AUTO_TEST_CASE(descriptor_checksum_optional)
+{
+    // Test that checksum is optional when require_checksum=false
+    FlatSigningProvider keys;
+    std::string error;
+    
+    std::string desc_without_checksum = "pkh(xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB)";
+    
+    auto descs = Parse(desc_without_checksum, keys, error, /*require_checksum=*/false);
+    BOOST_CHECK(!descs.empty());
+}
+
+BOOST_FIXTURE_TEST_CASE(g_descriptor_null_by_default, BasicTestingSetup)
+{
+    // When no descriptor is configured, g_descriptor is nullptr
+    g_descriptor.reset();
+    BOOST_CHECK(g_descriptor == nullptr);
+}
+
+BOOST_FIXTURE_TEST_CASE(g_descriptor_integration_test, BasicTestingSetup)
+{
+    // Verify that g_descriptor can be populated and accessed
+    g_descriptor.reset();
+
+    std::string desc_str = "pkh(xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB)";
+    FlatSigningProvider keys;
+    std::string error;
+    auto descs = Parse(desc_str, keys, error, /*require_checksum=*/false);
+
+    BOOST_REQUIRE(!descs.empty());
+    g_descriptor = std::move(descs.front());
+
+    BOOST_CHECK(g_descriptor != nullptr);
+    BOOST_CHECK_EQUAL(g_descriptor->GetOutputType(), OutputType::LEGACY);
+
+    // Clean up so other tests are not affected
+    g_descriptor.reset();
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/functional/feature_g_descriptor.py
+++ b/test/functional/feature_g_descriptor.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+# Copyright (c) 2024-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test the g_descriptor singleton and -descriptor config option."""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_node import ErrorMatch
+from test_framework import util
+
+
+class DescriptorTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        # Don't start nodes automatically - each test controls when they start
+        self.supports_cli = False
+        self.wallet_names = []
+
+    def setup_network(self):
+        """Override to prevent automatic network setup."""
+        self.setup_nodes()
+
+    def setup_nodes(self):
+        """Override to prevent automatic node startup."""
+        self.add_nodes(self.num_nodes)
+        # Ensure a log file exists as TestNode.assert_debug_log() expects it.
+        self.nodes[0].debug_log_path.parent.mkdir(exist_ok=True)
+        self.nodes[0].debug_log_path.touch(exist_ok=True)
+
+    def test_descriptor_optional(self):
+        """Test that -descriptor is optional and the node starts fine without it."""
+        self.log.info('Testing that -descriptor is optional')
+
+        self.start_node(0, extra_args=['-regtest'])
+        self.stop_node(0)
+
+    def test_descriptor_invalid(self):
+        """Test that invalid descriptors are rejected."""
+        self.log.info('Testing that invalid descriptors are rejected')
+        
+        # Try to start with an invalid descriptor
+        invalid_descriptor = 'invalid_descriptor_string'
+        self.nodes[0].assert_start_raises_init_error(
+            extra_args=['-regtest', f'-descriptor={invalid_descriptor}'],
+            expected_msg="Error: Invalid -descriptor 'invalid_descriptor_string': 'invalid_descriptor_string' is not a valid descriptor function",
+        )
+
+    def test_descriptor_valid_pkh(self):
+        """Test that valid pkh descriptors are accepted."""
+        self.log.info('Testing that valid pkh descriptors are accepted')
+        
+        # A valid pay-to-pubkey-hash descriptor
+        descriptor = 'pkh(02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5)'
+        
+        with self.nodes[0].assert_debug_log(timeout=60, expected_msgs=['Descriptor initialized successfully']):
+            self.start_node(0, extra_args=['-regtest', f'-descriptor={descriptor}'])
+        
+        # If we got here, the node started successfully
+        self.stop_node(0)
+
+    def test_descriptor_valid_wpkh(self):
+        """Test that valid wpkh descriptors are accepted."""
+        self.log.info('Testing that valid wpkh descriptors are accepted')
+        
+        # A valid witness pay-to-pubkey-hash descriptor
+        descriptor = 'wpkh(02f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9)'
+        
+        with self.nodes[0].assert_debug_log(timeout=60, expected_msgs=['Descriptor initialized successfully']):
+            self.start_node(0, extra_args=['-regtest', f'-descriptor={descriptor}'])
+        
+        self.stop_node(0)
+
+    def test_descriptor_valid_tr(self):
+        """Test that valid Taproot descriptors are accepted."""
+        self.log.info('Testing that valid Taproot descriptors are accepted')
+        
+        # A valid Taproot descriptor
+        descriptor = 'tr(c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5,{pk(fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556),pk(e493dbf1c10d80f3581e4904930b1404cc6c13900ee0758474fa94abe8c4cd13)})'
+        
+        with self.nodes[0].assert_debug_log(timeout=60, expected_msgs=['Descriptor initialized successfully']):
+            self.start_node(0, extra_args=['-regtest', f'-descriptor={descriptor}'])
+        
+        self.stop_node(0)
+
+    def test_descriptor_in_config_file(self):
+        """Test that -descriptor can be specified in bitcoin.conf."""
+        self.log.info('Testing that -descriptor can be specified in bitcoin.conf')
+        
+        descriptor = 'wpkh(02f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9)'
+        
+        # Write descriptor to config file
+        conf_path = self.nodes[0].datadir_path / 'bitcoin.conf'
+        with open(conf_path, 'a', encoding='utf-8') as conf:
+            conf.write(f'descriptor={descriptor}\n')
+        
+        # Start node with only regtest flag, descriptor should be read from config
+        with self.nodes[0].assert_debug_log(timeout=60, expected_msgs=['Descriptor initialized successfully']):
+            self.start_node(0, extra_args=['-regtest'])
+        
+        self.stop_node(0)
+
+    def test_descriptor_malformed_key(self):
+        """Test that descriptors with malformed keys are rejected."""
+        self.log.info('Testing that descriptors with malformed keys are rejected')
+        
+        # A descriptor with an invalid key
+        descriptor = 'pkh(invalid_key)'
+        
+        self.nodes[0].assert_start_raises_init_error(
+            extra_args=['-regtest', f'-descriptor={descriptor}'],
+            expected_msg="Error: Invalid -descriptor 'pkh(invalid_key)': pkh(): key 'invalid_key' is not valid",
+        )
+
+    def run_test(self):
+        """Run all descriptor tests."""
+        self.test_descriptor_optional()
+        self.test_descriptor_invalid()
+        self.test_descriptor_valid_pkh()
+        self.test_descriptor_valid_wpkh()
+        self.test_descriptor_valid_tr()
+        self.test_descriptor_in_config_file()
+        self.test_descriptor_malformed_key()
+
+
+if __name__ == '__main__':
+    DescriptorTest(__file__).main()


### PR DESCRIPTION
Introduce a new command-line/bitcoin.conf option (-descriptor) that accepts an externally provided descriptor value. The argument is validated at init and made globally accessible throughout the codebase.