### PR TITLE
build: add Nix flake and start script for dev environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ target/
 /guix-build-*
 
 /ci/scratch/
+
+# Quorumeum local data
+/.quorumeum-data/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1771848320,
+        "narHash": "sha256-0MAd+0mun3K/Ns8JATeHT1sX28faLII5hVLq0L3BdZU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2fc6539b481e1d2569f25f8799236694180c0993",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,81 @@
+{
+  description = "Quorumeum - Bitcoin Core fork";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          nativeBuildInputs = with pkgs; [
+            cmake
+            pkg-config
+            python3
+            hexdump
+          ];
+
+          buildInputs = with pkgs; [
+            boost
+            libevent
+            sqlite
+            zeromq
+            zlib
+            capnproto
+            miniupnpc
+            libnatpmp
+          ] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
+            qt6.qtbase
+            qt6.qttools
+            qrencode
+          ];
+
+          shellHook = ''
+            bash "$PWD/start.sh"
+            export PATH="$PWD/build/bin:$PATH"
+          '';
+        };
+
+        packages.default = pkgs.stdenv.mkDerivation {
+          pname = "quorumeum";
+          version = "30.2.0";
+
+          src = self;
+
+          nativeBuildInputs = with pkgs; [
+            cmake
+            pkg-config
+            python3
+            hexdump
+          ];
+
+          buildInputs = with pkgs; [
+            boost
+            libevent
+            sqlite
+            zeromq
+            zlib
+            capnproto
+            miniupnpc
+            libnatpmp
+          ];
+
+          cmakeFlags = [
+            "-DBUILD_GUI=OFF"
+            "-DWITH_QRENCODE=OFF"
+          ];
+
+          meta = with pkgs.lib; {
+            description = "Quorumeum node";
+            license = licenses.mit;
+            platforms = platforms.unix;
+          };
+        };
+      }
+    );
+}

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+#
+# Quorumeum start script
+#
+# Writes the custom signet config, builds from source if needed,
+# and starts the node. Works standalone or via `nix develop`.
+#
+# Usage:
+#   ./start.sh          # build + start node
+#   ./start.sh --stop   # stop the node
+#   ./start.sh --clean  # remove build and data dirs
+#
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
+BUILD_DIR="${QUORUMEUM_BUILD_DIR:-$REPO_DIR/build}"
+DATADIR="${QUORUMEUM_DATADIR:-$REPO_DIR/.quorumeum-data}"
+
+SIGNET_CHALLENGE="51208d8dfd7fdc663efe1d54f05182fddddd7cf47ba3ed6e6932eccd41b7722da91b"
+SIGNET_SEED_NODE="167.71.167.51"
+
+BITCOIND="$BUILD_DIR/bin/bitcoind"
+BITCOIN_CLI="$BUILD_DIR/bin/bitcoin-cli"
+
+cli() {
+  "$BITCOIN_CLI" -datadir="$DATADIR" "$@"
+}
+
+node_is_running() {
+  cli getblockchaininfo &>/dev/null
+}
+
+write_config() {
+  mkdir -p "$DATADIR"
+  cat > "$DATADIR/bitcoin.conf" <<EOF
+signet=1
+
+[signet]
+signetchallenge=$SIGNET_CHALLENGE
+connect=$SIGNET_SEED_NODE
+EOF
+  echo "==> Config written to $DATADIR/bitcoin.conf"
+}
+
+check_deps() {
+  local missing=()
+  for cmd in cmake pkg-config python3; do
+    if ! command -v "$cmd" &>/dev/null; then
+      missing+=("$cmd")
+    fi
+  done
+  if [ ${#missing[@]} -gt 0 ]; then
+    echo "==> Missing build dependencies: ${missing[*]}"
+    echo "    Install them with your package manager, e.g.:"
+    echo "      apt install ${missing[*]}       # Debian/Ubuntu"
+    echo "      brew install ${missing[*]}      # macOS"
+    echo "    Or use 'nix develop' to get everything automatically."
+    return 1
+  fi
+}
+
+build() {
+  if [ -f "$BITCOIND" ]; then
+    echo "==> Build already exists at $BUILD_DIR. Delete it or run './start.sh --clean' to rebuild."
+    return 0
+  fi
+
+  check_deps
+
+  echo "==> Configuring Quorumeum..."
+  cmake -B "$BUILD_DIR" -S "$REPO_DIR" \
+    -DBUILD_GUI=OFF \
+    -DWITH_QRENCODE=OFF \
+    -DWITH_ZMQ=OFF
+
+  local jobs
+  jobs=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
+  echo "==> Building with $jobs parallel jobs..."
+  cmake --build "$BUILD_DIR" -j"$jobs"
+
+  echo "==> Build complete."
+}
+
+start_node() {
+  if node_is_running; then
+    echo "==> Quorumeum node is already running."
+    return 0
+  fi
+
+  if [ ! -f "$BITCOIND" ]; then
+    echo "==> bitcoind not found at $BITCOIND"
+    echo "    Run './start.sh' without flags to build first."
+    return 1
+  fi
+
+  echo "==> Starting Quorumeum node on custom signet..."
+  "$BITCOIND" -datadir="$DATADIR" -daemon
+
+  echo "==> Waiting for node to be ready..."
+  for i in $(seq 1 30); do
+    if node_is_running; then
+      echo "==> Quorumeum node is ready!"
+      echo ""
+      echo "    qcli getblockchaininfo    # query the node"
+      echo "    qcli getpeerinfo          # see connected peers"
+      echo "    qcli help                 # list all commands"
+      echo "    qcli stop                 # stop the node"
+      echo ""
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "==> Node did not become ready within 30s. Check logs at $DATADIR/signet/debug.log"
+  return 1
+}
+
+stop_node() {
+  if node_is_running; then
+    echo "==> Stopping Quorumeum node..."
+    cli stop
+    echo "==> Node stopped."
+  else
+    echo "==> Node is not running."
+  fi
+}
+
+clean() {
+  stop_node 2>/dev/null || true
+  echo "==> Removing build dir: $BUILD_DIR"
+  rm -rf "$BUILD_DIR"
+  echo "==> Removing data dir: $DATADIR"
+  rm -rf "$DATADIR"
+  echo "==> Clean complete."
+}
+
+setup_qcli() {
+  # Create a qcli wrapper script in the build bin dir
+  cat > "$BUILD_DIR/bin/qcli" <<WRAPPER
+#!/usr/bin/env bash
+exec "$BITCOIN_CLI" -datadir="$DATADIR" "\$@"
+WRAPPER
+  chmod +x "$BUILD_DIR/bin/qcli"
+}
+
+case "${1:-}" in
+  --stop)
+    stop_node
+    ;;
+  --clean)
+    clean
+    ;;
+  *)
+    write_config
+    build
+    setup_qcli
+    start_node
+    ;;
+esac


### PR DESCRIPTION
## description / motivation

this adds a nix-friendly dev shell for nix users as well as a nix-agnostic start script to make it easy just to just get the node running and ready for some cli tinkering

if you don't use nix you'll have to figure out how to compile bitcoin core yourself

you can see the output of this being tested on my machine (with nix) here: https://gist.github.com/otech47/9b031a4279e80f2670aedefc917f176e

## how to test this PR

1. Add the fork as a remote and checkout the branch

```
git remote add otech47 https://github.com/otech47/quorumeum.git
git fetch otech47
git checkout otech47/nix-dev-environment
```

2. Build bitcoin

With Nix installed (easiest — handles building bitcoin core with all deps, guide to install Nix & enable flakes [here](https://github.com/fedimint/fedimint/blob/master/docs/dev-env.md#set-up-nix)):
`nix develop`

Without Nix (requires cmake, boost, libevent, sqlite installed, will make a best-effort attempt to build bitcoin core):
`./start.sh`

3. Interact with the node

(qcli is just a bitcoin-cli wrapper)

```
qcli getblockchaininfo
qcli getpeerinfo
qcli help
```

4. Stop the node when done
```
qcli stop
# or
./start.sh --stop
```