### PR TITLE
debug: add debug option for signetpsbt

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -201,6 +201,7 @@ static const std::map<std::string, BCLog::LogFlags, std::less<>> LOG_CATEGORIES_
     {"txreconciliation", BCLog::TXRECONCILIATION},
     {"scan", BCLog::SCAN},
     {"txpackages", BCLog::TXPACKAGES},
+    {"signetpsbt", BCLog::SIGNETPSBT},
 };
 
 static const std::unordered_map<BCLog::LogFlags, std::string> LOG_CATEGORIES_BY_FLAG{

--- a/src/logging.h
+++ b/src/logging.h
@@ -94,6 +94,7 @@ namespace BCLog {
         TXRECONCILIATION = (CategoryMask{1} << 26),
         SCAN        = (CategoryMask{1} << 27),
         TXPACKAGES  = (CategoryMask{1} << 28),
+        SIGNETPSBT = (CategoryMask{1} << 29),
         ALL         = ~NONE,
     };
     enum class Level {


### PR DESCRIPTION
Add a debug option to log `SIGNETPSBT` stuff.

To use it just add a line like:

```c++
LogDebug(BCLog::SIGNETPSBT, "I amb debuging psbt signet things!!.\n");
```

And start bitcoind with
```bash
./bitcoind -debug=signetpsbt
```


This is usefull to test and log when codding other requirements.