### PR TITLE
Basic signetpsbt p2p test

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3735,6 +3735,9 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
         // 5.1 Otherwise: Continue to relay the PSBT without further adjustment to peers
         // for peer in peers:
             //MakeAndPushMessage(peer, NetMsgType::SIGNETPSBT, blocktemplate);
+        
+        // Adding this just to have something to test for now
+        LogDebug(BCLog::NET, "Processed signetpsbt message from peer=%d\n", pfrom.GetId());
     }
 
     if (msg_type == NetMsgType::SENDHEADERS) {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -45,6 +45,7 @@
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <protocol.h>
+#include <psbt.h>
 #include <random.h>
 #include <scheduler.h>
 #include <script/script.h>
@@ -3710,6 +3711,30 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
 
         pfrom.fSuccessfullyConnected = true;
         return;
+    }
+
+    if (msg_type == NetMsgType::SIGNETPSBT) {
+        PartiallySignedTransaction psbt;
+        std::shared_ptr<CBlock> pblock = std::make_shared<CBlock>();
+
+        vRecv >> psbt;
+        vRecv >> TX_WITH_WITNESS(*pblock);
+        // TODO
+        // 1. Validate block template
+
+        // 2. Verify that the PSBT commits to the block template according to BIP 325
+
+        // 3. Verify all current signatures in the PSBT
+
+        // 4. If the PSBT does not have enough signatures to meet the multisig threshold AND this node has a Quorumeum multisig private key AND it has not signed the PSBT yet, it computes a signature and adds it to the PSBT, updating the message.
+
+        // 5. If the PSBT has enough signatures to meet the multisig threshold:
+            // - Grind the block header nonce until the proof of work is satisfied
+            // - Relay the finished block to peers
+
+        // 5.1 Otherwise: Continue to relay the PSBT without further adjustment to peers
+        // for peer in peers:
+            //MakeAndPushMessage(peer, NetMsgType::SIGNETPSBT, blocktemplate);
     }
 
     if (msg_type == NetMsgType::SENDHEADERS) {

--- a/test/functional/feature_signetpsbt_p2p.py
+++ b/test/functional/feature_signetpsbt_p2p.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+# Copyright (c) The Quorumeum developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test signetpsbt P2P message"""
+
+import importlib.machinery
+import importlib.util
+import logging
+import os
+
+from test_framework.messages import hash256, msg_signetpsbt, ser_compact_size
+from test_framework.p2p import P2PInterface
+from test_framework.test_framework import BitcoinTestFramework
+
+SIGNERS = 2
+MULTISIG_KEYS = 4
+KEYS = MULTISIG_KEYS + 1
+
+
+class SignetPsbtP2PTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.chain = "signet"
+        self.num_nodes = 2
+        self.setup_clean_chain = True
+
+    def setup_network(self):
+        self.add_nodes(self.num_nodes, extra_args=[[], ["-disablewallet"]])
+        self.start_nodes()
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        signet_miner_path = os.path.join(
+            self.config["environment"]["SRCDIR"], "contrib", "signet", "miner"
+        )
+        loader = importlib.machinery.SourceFileLoader("miner", signet_miner_path)
+        spec = importlib.util.spec_from_loader(loader.name, loader)
+        self.SignetMiner = importlib.util.module_from_spec(spec)
+        loader.exec_module(self.SignetMiner)
+        logging.getLogger().handlers.clear()
+
+        self.create_wallets()
+        self.keypairs = self.get_extended_key_pairs()
+        self.multisig_descriptors = self.get_multisig_descriptors()
+        self.signet_challenge = self.get_signet_challenge()
+        self.switch_nodes()
+        self.test_signetpsbt_p2p_message()
+
+    def create_wallets(self):
+        self.log.info("Creating %d wallets", KEYS)
+        for i in range(KEYS):
+            self.nodes[0].createwallet(wallet_name=f"wallet_{i}")
+
+    def get_extended_key_pairs(self):
+        self.log.info("Getting prv/pub key pairs from each wallet")
+        ret = []
+        for i in range(KEYS):
+            pub = None
+            prv = None
+            wallet = self.nodes[0].get_wallet_rpc(f"wallet_{i}")
+            descs = wallet.listdescriptors(private=True)["descriptors"]
+            for desc in descs:
+                if desc["desc"].startswith("tr("):
+                    prv = desc["desc"].split("(")[1].split("*")[0]
+                    prv += "0"
+                    break
+            descs = wallet.listdescriptors()["descriptors"]
+            for desc in descs:
+                if desc["desc"].startswith("tr("):
+                    pub = desc["desc"].split("]")[1].split("*")[0]
+                    pub += "0"
+                    break
+            ret.append({"prv": prv, "pub": pub})
+        return ret
+
+    def choose_keys(self, signer_index):
+        ret = []
+        for keypair_index, keypair in enumerate(self.keypairs):
+            ret.append(keypair["prv"] if keypair_index == signer_index else keypair["pub"])
+        return ret
+
+    def get_multisig_descriptors(self):
+        self.log.info("Constructing %d multisig descriptors with one private key each", KEYS)
+        ret = []
+        for i in range(KEYS):
+            keys = self.choose_keys(i)
+            desc = f"tr({keys[0]},multi_a({SIGNERS}"
+            for key in keys[1:]:
+                desc += f",{key}"
+            desc += "))"
+            descinfo = self.nodes[0].getdescriptorinfo(desc)
+            desc += f"#{descinfo['checksum']}"
+            ret.append(desc)
+        return ret
+
+    def get_signet_challenge(self):
+        self.log.info("Verifying all %d wallets derive the same address", KEYS)
+        # self.log.info(f"Using descriptor: {self.multisig_descriptors}")
+        key0_addr = self.nodes[0].deriveaddresses(self.multisig_descriptors[0])[0]
+        self.log.info("Address: %s", key0_addr)
+        for desc in self.multisig_descriptors:
+            assert key0_addr == self.nodes[0].deriveaddresses(desc)[0]
+        wallet0 = self.nodes[0].get_wallet_rpc("wallet_0")
+        program = wallet0.getaddressinfo(address=key0_addr)["scriptPubKey"]
+        self.log.info("scriptPubKey (signet challenge): %s", program)
+        return program
+
+    def switch_nodes(self):
+        self.log.info("Starting a node on the new Quorumeum Signet chain")
+        self.restart_node(1, extra_args=[f"-signetchallenge={self.signet_challenge}"], clear_addrman=True)
+        assert self.nodes[0].getblockchaininfo()["signet_challenge"] != self.signet_challenge
+        self.stop_node(0)
+        assert self.nodes[1].getblockchaininfo()["signet_challenge"] == self.signet_challenge
+
+    def get_commitment_data(self):
+        self.log.info("Generating block template and PSBT")
+        reward_spk = bytes.fromhex("51")
+        self.log.info("Getting block template")
+        tmpl = self.nodes[1].getblocktemplate({"rules": ["signet", "segwit"]})
+        block = self.SignetMiner.new_block(tmpl, reward_spk)
+        psbt = self.SignetMiner.generate_psbt(block, tmpl["signet_challenge"])
+        return block, psbt
+
+    def test_signetpsbt_p2p_message(self):
+        """Phase 1: Send valid signetpsbt message; node should not disconnect."""
+        self.log.info("Setting up node with signet signing descriptor")
+        self.nodes[1].createwallet(wallet_name="wallet_0", blank=True)
+        wallet = self.nodes[1].get_wallet_rpc("wallet_0")
+        wallet.importdescriptors([{
+            "desc": self.multisig_descriptors[0],
+            "timestamp": 0,
+        }])
+
+        self.log.info("Sending signetpsbt message (PSBT + block) over P2P")
+        block, psbt_base64 = self.get_commitment_data()
+        decoded_psbt = self.SignetMiner.decode_challenge_psbt(psbt_base64)
+
+        msg = msg_signetpsbt(psbt=decoded_psbt, block=block)
+        # Using custom signet magic: first 4 bytes of SHA256d(serialized signet_challenge).
+        # C++ chainparams serializes the vector as compact_size(len) + bytes before hashing.
+        challenge_bytes = bytes.fromhex(self.signet_challenge)
+        serialized = ser_compact_size(len(challenge_bytes)) + challenge_bytes
+        signet_magic = hash256(serialized)[:4]
+
+        peer = self.nodes[1].add_p2p_connection(
+            P2PInterface(), magic_bytes=signet_magic, supports_v2_p2p=False
+        )
+        with self.nodes[1].assert_debug_log(["Processed signetpsbt message"]):
+            peer.send_and_ping(msg)
+
+        assert peer.is_connected
+
+
+if __name__ == '__main__':
+    SignetPsbtP2PTest(__file__).main()

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -1363,6 +1363,27 @@ class msg_block:
         return "msg_block(block=%s)" % (repr(self.block))
 
 
+class msg_signetpsbt:
+    __slots__ = ("psbt", "block")
+    msgtype = b"signetpsbt"
+
+    def __init__(self, psbt=None, block=None):
+        self.psbt = psbt
+        self.block = block
+
+    def deserialize(self, f):
+        from test_framework.psbt import PSBT
+        self.psbt = from_binary(PSBT, f)
+        self.block = from_binary(CBlock, f)
+        return self
+
+    def serialize(self):
+        return self.psbt.serialize() + self.block.serialize(with_witness=True)
+
+    def __repr__(self):
+        return "msg_signetpsbt(psbt=%s, block=%s)" % (repr(self.psbt), repr(self.block))
+
+
 # Generic type to control the raw bytes sent over the wire.
 # The msgtype and the data must be provided.
 class msg_generic:

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -64,6 +64,7 @@ from test_framework.messages import (
     msg_sendcmpct,
     msg_sendheaders,
     msg_sendtxrcncl,
+    msg_signetpsbt,
     msg_tx,
     MSG_TX,
     MSG_TYPE_MASK,
@@ -142,6 +143,7 @@ MESSAGEMAP = {
     b"sendcmpct": msg_sendcmpct,
     b"sendheaders": msg_sendheaders,
     b"sendtxrcncl": msg_sendtxrcncl,
+    b"signetpsbt": msg_signetpsbt,
     b"tx": msg_tx,
     b"verack": msg_verack,
     b"version": msg_version,
@@ -180,7 +182,7 @@ class P2PConnection(asyncio.Protocol):
     def supports_v2_p2p(self):
         return self.v2_state is not None
 
-    def peer_connect_helper(self, dstaddr, dstport, net, timeout_factor):
+    def peer_connect_helper(self, dstaddr, dstport, net, timeout_factor, magic_bytes=None):
         assert not self.is_connected
         self.timeout_factor = timeout_factor
         self.dstaddr = dstaddr
@@ -188,11 +190,11 @@ class P2PConnection(asyncio.Protocol):
         # The initial message to send after the connection was made:
         self.on_connection_send_msg = None
         self.recvbuf = b""
-        self.magic_bytes = MAGIC_BYTES[net]
+        self.magic_bytes = magic_bytes if magic_bytes is not None else MAGIC_BYTES[net]
         self.p2p_connected_to_node = dstport != 0
 
-    def peer_connect(self, dstaddr, dstport, *, net, timeout_factor, supports_v2_p2p):
-        self.peer_connect_helper(dstaddr, dstport, net, timeout_factor)
+    def peer_connect(self, dstaddr, dstport, *, net, timeout_factor, supports_v2_p2p, magic_bytes=None):
+        self.peer_connect_helper(dstaddr, dstport, net, timeout_factor, magic_bytes)
         if supports_v2_p2p:
             self.v2_state = EncryptedP2PState(initiating=True, net=net)
 
@@ -556,6 +558,7 @@ class P2PInterface(P2PConnection):
     def on_sendcmpct(self, message): pass
     def on_sendheaders(self, message): pass
     def on_sendtxrcncl(self, message): pass
+    def on_signetpsbt(self, message): pass
     def on_tx(self, message): pass
     def on_wtxidrelay(self, message): pass
 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -283,6 +283,7 @@ BASE_SCRIPTS = [
     # 'mining_mainnet.py',
     'feature_signet.py',
     'feature_quorumeum.py',
+    'feature_signetpsbt_p2p.py',
     # 'p2p_mutated_blocks.py',
     # 'rpc_named_arguments.py',
     # 'feature_startupnotify.py',


### PR DESCRIPTION
### Context

This adds the `signetpsbt` P2P message for transporting PSBTs and block templates between peers for Quorumeum’s signet-style block mining. The handler currently just parses and log messages. This test (for now) is just making sure that the receiving node doesn't disconnect and that the final log reached.

### Changes

- **Test framework**: Add `msg_signetpsbt` in `messages.py` and register it in `p2p.py`. Support custom `magic_bytes` in P2P connections for signet.
- **Functional test**: Add `feature_signetpsbt_p2p.py` to send a signetpsbt message to a node with a custom signet challenge and assert it is processed.
- **Test runner**: Include `feature_signetpsbt_p2p.py` in `BASE_SCRIPTS`.