### PR TITLE
WIP: logic to extract and validate block from PSBT

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3,6 +3,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include "psbt.h"
 #include <net_processing.h>
 
 #include <addrman.h>
@@ -3710,6 +3711,51 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
 
         pfrom.fSuccessfullyConnected = true;
         return;
+    }
+
+    if (msg_type == NetMsgType::SIGNETPSBT) {
+        PartiallySignedTransaction psbt;
+        std::shared_ptr<CBlock> pblock = std::make_shared<CBlock>();
+
+        vRecv >> psbt;
+
+        std::string decode_error;
+        std::vector<uint8_t> signet_block_key;
+        static constexpr std::string_view SIGNET_ID{"signetb"};
+        signet_block_key.push_back(0xFC);
+        signet_block_key.push_back(0x06);
+        signet_block_key.insert(
+            signet_block_key.end(),
+            SIGNET_ID.begin(),
+            SIGNET_ID.end()
+        );
+
+        // TODO: change to use psbt m_propietary field
+        auto block_bytes = psbt.unknown.find(signet_block_key);
+
+        if (block_bytes == psbt.unknown.end()) {
+            LogDebug(BCLog::NET, "peer=%d PSBT missing PSBT_SIGNET_BLOCK field\n", pfrom.GetId());
+            return;
+        }
+
+        CBlock& block = *pblock;
+        try {
+            DataStream block_stream{block_bytes->second};
+            block_stream >> TX_WITH_WITNESS(block);  // standard CBlock deserialization
+        } catch (const std::exception& e) {
+            LogDebug(BCLog::NET, "peer=%d failed to deserialize signet block: %s\n",
+            pfrom.GetId(), e.what());
+            return;
+        }
+
+        LogDebug(BCLog::NET, "received block %s", pblock->GetHash().ToString());
+
+        BlockValidationState state;
+        if (!CheckBlock(block, state, m_chainman.GetParams().GetConsensus())) {
+            LogDebug(BCLog::NET, "peer=%d signet block failed CheckBlock: %s\n",
+            pfrom.GetId(), state.GetRejectReason());
+            return;
+        }
     }
 
     if (msg_type == NetMsgType::SENDHEADERS) {

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -1667,6 +1667,24 @@ class msg_sendcmpct:
     def __repr__(self):
         return "msg_sendcmpct(announce=%s, version=%lu)" % (self.announce, self.version)
 
+class msg_signetpsbt:
+    from test_framework.psbt import PSBT
+
+    __slots__ = ("psbt")
+    msgtype =  b"signetpsbt"
+
+    def __init__(self, psbt=PSBT()):
+        self.psbt = psbt
+
+    def deserialize(self, f):
+        from test_framework.psbt import PSBT
+        self.psbt = PSBT.deserialize(f)
+
+    def serialize(self):
+        return self.psbt.serialize()
+
+    def __repr__(self):
+        return "msg_signetpsbt(psbt={})".format(self.psbt)
 
 class msg_cmpctblock:
     __slots__ = ("header_and_shortids",)

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -283,6 +283,7 @@ BASE_SCRIPTS = [
     # 'mining_mainnet.py',
     'feature_signet.py',
     'feature_quorumeum.py',
+    'p2p_signetpsbt.py',
     # 'p2p_mutated_blocks.py',
     # 'rpc_named_arguments.py',
     # 'feature_startupnotify.py',


### PR DESCRIPTION
**Description**

I extracted the block from the `PSBT_SIGNET_BLOCK` field and created a test sending it throw the p2p layer with the test framework.

Is not working so far because I don't know how to create a `PSBTPropietary` field and extract it from the `PSBT` struct.

To test it I compiled the code and executed:

```bash
$ build/test/functional/p2p_signetpsbt.py
```

And as I included `import pdb; pdb.set_trace()` in the test, is easier to copy the temporary directory of the test and check the msg is received by the nodes `tail -f /tmp/bitcoin_func_test_<random>/node0/regtest/debug.log`.


Related to #47 